### PR TITLE
Add OpenCode local provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ Updates are delivered automatically; no reinstall needed for future versions.
 4. Click **✕** next to an item to remove it, or **🗑** in the header to clear everything
 5. Click **🗑** in the header to clear all saved items
 
+
+## Debugging
+
+if clipboard manager refuses to connect, try this to allow CORS
+
+```bash
+opencode serve --hostname 127.0.0.1 --port 4096 --cors moz-extension://<extension-id>
+```
+
+Also, use your real runtime extension ID from Firefox (`browser.runtime.id`), especially for temporary add-ons.
+
 ## File Structure
 
 ```

--- a/background.js
+++ b/background.js
@@ -9,6 +9,22 @@ browser.runtime.onInstalled.addListener(function(details) {
     }
 });
 
+const OPENCODE_DEFAULT_URL = 'http://127.0.0.1:4096';
+const OPENCODE_SESSION_MAP_KEY = 'opencodeSessionsByPage';
+
+function parseErrorPayload(text) {
+    if (!text) return '';
+    try {
+        const json = JSON.parse(text);
+        if (json.error && typeof json.error.message === 'string') return json.error.message;
+        if (json.data && typeof json.data.message === 'string') return json.data.message;
+        if (typeof json.message === 'string') return json.message;
+        return text;
+    } catch (e) {
+        return text;
+    }
+}
+
 // --- Provider-specific API handlers ---
 
 function callGemini(apiKey, requestBody) {
@@ -145,6 +161,236 @@ function callOpenRouter(apiKey, requestBody) {
     });
 }
 
+function normalizeOpenCodeUrl(url) {
+    const raw = (url || '').trim();
+    if (!raw) return OPENCODE_DEFAULT_URL;
+    return raw.replace(/\/$/, '');
+}
+
+function createOpenCodeAuthHeader(password) {
+    if (!password) return null;
+    return `Basic ${btoa(`opencode:${password}`)}`;
+}
+
+function buildOpenCodeCorsHint(baseUrl) {
+    const extensionOrigin = `moz-extension://${browser.runtime.id}`;
+    let hostname = '127.0.0.1';
+    let port = '4096';
+
+    try {
+        const parsed = new URL(baseUrl);
+        if (parsed.hostname) hostname = parsed.hostname;
+        if (parsed.port) {
+            port = parsed.port;
+        } else if (parsed.protocol === 'https:') {
+            port = '443';
+        } else {
+            port = '80';
+        }
+    } catch (e) {
+        // Keep defaults
+    }
+
+    return `Cannot reach OpenCode server at ${baseUrl}. If it is local, run:\nopencode serve --hostname ${hostname} --port ${port} --cors ${extensionOrigin}`;
+}
+
+async function openCodeFetch(baseUrl, password, path, options = {}) {
+    const authHeader = createOpenCodeAuthHeader(password);
+    const headers = Object.assign({}, options.headers || {});
+    if (options.method && options.method !== 'GET') {
+        headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+    }
+    if (authHeader) headers['Authorization'] = authHeader;
+
+    const url = `${baseUrl}${path}`;
+    let response;
+    try {
+        response = await fetch(url, Object.assign({}, options, { headers }));
+    } catch (error) {
+        throw new Error(`${buildOpenCodeCorsHint(baseUrl)}\nDetails: ${error.message || 'Network error'}`);
+    }
+
+    if (!response.ok) {
+        const text = await response.text();
+        const message = parseErrorPayload(text) || response.statusText || 'Request failed';
+        if (response.status === 401) {
+            throw new Error('OpenCode authentication failed. Check the Server Password in settings.');
+        }
+        throw new Error(`OpenCode request failed (${response.status}): ${message}`);
+    }
+
+    if (response.status === 204) {
+        return null;
+    }
+
+    const text = await response.text();
+    if (!text) return {};
+    try {
+        return JSON.parse(text);
+    } catch (e) {
+        throw new Error('OpenCode returned an invalid JSON response.');
+    }
+}
+
+function storageGet(keys) {
+    return new Promise(resolve => {
+        browser.storage.local.get(keys, resolve);
+    });
+}
+
+function storageSet(values) {
+    return new Promise(resolve => {
+        browser.storage.local.set(values, resolve);
+    });
+}
+
+async function getOpenCodeSessionMap() {
+    const result = await storageGet([OPENCODE_SESSION_MAP_KEY]);
+    const map = result[OPENCODE_SESSION_MAP_KEY];
+    if (map && typeof map === 'object') return map;
+    return {};
+}
+
+async function setOpenCodeSessionMap(map) {
+    await storageSet({ [OPENCODE_SESSION_MAP_KEY]: map });
+}
+
+async function getOpenCodeSessionId(pageKey) {
+    const map = await getOpenCodeSessionMap();
+    return map[pageKey] || null;
+}
+
+async function saveOpenCodeSessionId(pageKey, sessionId) {
+    const map = await getOpenCodeSessionMap();
+    map[pageKey] = sessionId;
+    await setOpenCodeSessionMap(map);
+}
+
+async function clearOpenCodeSessionId(pageKey) {
+    const map = await getOpenCodeSessionMap();
+    if (map[pageKey]) {
+        delete map[pageKey];
+        await setOpenCodeSessionMap(map);
+    }
+}
+
+async function createOpenCodeSession(baseUrl, password, pageKey) {
+    const title = pageKey ? `Page: ${pageKey.slice(0, 120)}` : undefined;
+    const body = title ? { title } : {};
+    const data = await openCodeFetch(baseUrl, password, '/session', {
+        method: 'POST',
+        body: JSON.stringify(body)
+    });
+
+    if (!data || !data.id) {
+        throw new Error('OpenCode did not return a session ID.');
+    }
+    return data.id;
+}
+
+async function ensureOpenCodeSession(baseUrl, password, pageKey) {
+    const existing = await getOpenCodeSessionId(pageKey);
+    if (existing) return existing;
+    const created = await createOpenCodeSession(baseUrl, password, pageKey);
+    await saveOpenCodeSessionId(pageKey, created);
+    return created;
+}
+
+function shouldRetryWithNewSession(error) {
+    const message = (error && error.message) ? error.message : '';
+    return /\(404\)/.test(message);
+}
+
+function extractOpenCodeText(parts) {
+    if (!Array.isArray(parts)) return '';
+    return parts
+        .filter(part => part && part.type === 'text' && typeof part.text === 'string')
+        .map(part => part.text)
+        .join('\n\n')
+        .trim();
+}
+
+async function callOpenCode(opencodeConfig, requestBody, pageKey) {
+    const baseUrl = normalizeOpenCodeUrl(opencodeConfig && opencodeConfig.baseUrl);
+    const password = (opencodeConfig && opencodeConfig.password) ? opencodeConfig.password : '';
+    const scopedPageKey = pageKey || 'default';
+
+    if (!requestBody || !Array.isArray(requestBody.parts) || requestBody.parts.length === 0) {
+        throw new Error('OpenCode request is missing message parts.');
+    }
+
+    await openCodeFetch(baseUrl, password, '/global/health', { method: 'GET' });
+
+    let sessionId = await ensureOpenCodeSession(baseUrl, password, scopedPageKey);
+    let data;
+
+    try {
+        data = await openCodeFetch(baseUrl, password, `/session/${encodeURIComponent(sessionId)}/message`, {
+            method: 'POST',
+            body: JSON.stringify(requestBody)
+        });
+    } catch (error) {
+        if (!shouldRetryWithNewSession(error)) {
+            throw error;
+        }
+
+        await clearOpenCodeSessionId(scopedPageKey);
+        sessionId = await ensureOpenCodeSession(baseUrl, password, scopedPageKey);
+        data = await openCodeFetch(baseUrl, password, `/session/${encodeURIComponent(sessionId)}/message`, {
+            method: 'POST',
+            body: JSON.stringify(requestBody)
+        });
+    }
+
+    const text = extractOpenCodeText(data && data.parts);
+    if (!text) {
+        throw new Error('No response generated');
+    }
+
+    return text;
+}
+
+async function getOpenCodeModels(opencodeConfig) {
+    const baseUrl = normalizeOpenCodeUrl(opencodeConfig && opencodeConfig.baseUrl);
+    const password = (opencodeConfig && opencodeConfig.password) ? opencodeConfig.password : '';
+
+    await openCodeFetch(baseUrl, password, '/global/health', { method: 'GET' });
+    const providersData = await openCodeFetch(baseUrl, password, '/config/providers', { method: 'GET' });
+
+    const providers = Array.isArray(providersData && providersData.providers) ? providersData.providers : [];
+    const defaults = providersData && typeof providersData.default === 'object' ? providersData.default : {};
+
+    const models = [];
+    providers.forEach(provider => {
+        if (!provider || !provider.id || !provider.models || typeof provider.models !== 'object') {
+            return;
+        }
+
+        Object.keys(provider.models).forEach(modelKey => {
+            const model = provider.models[modelKey] || {};
+            if (model.status === 'deprecated') return;
+
+            const id = `${provider.id}/${modelKey}`;
+            const label = model.name ? `${model.name} (${provider.id})` : id;
+            models.push({ value: id, label });
+        });
+    });
+
+    models.sort((a, b) => a.label.localeCompare(b.label));
+
+    let defaultModel = '';
+    const defaultProviders = Object.keys(defaults);
+    if (defaultProviders.length > 0) {
+        const providerID = defaultProviders[0];
+        const modelID = defaults[providerID];
+        if (providerID && modelID) {
+            defaultModel = `${providerID}/${modelID}`;
+        }
+    }
+
+    return { models, defaultModel };
+}
+
 // Handle messages from content scripts
 browser.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     if (request.type === 'getSyncKey') {
@@ -156,12 +402,23 @@ browser.runtime.onMessage.addListener(function(request, sender, sendResponse) {
         });
         return true;
     }
-    
+
+    if (request.type === 'getOpenCodeModels') {
+        getOpenCodeModels(request.opencodeConfig)
+            .then(data => {
+                sendResponse({ success: true, models: data.models, defaultModel: data.defaultModel || '' });
+            })
+            .catch(error => {
+                sendResponse({ success: false, error: error.message });
+            });
+        return true;
+    }
+
     // Handle API requests from content script (to avoid CORS)
     if (request.type === 'sendToAPI') {
-        const { apiKey, requestBody, provider } = request;
+        const { apiKey, requestBody, provider, opencodeConfig, pageKey } = request;
         const selectedProvider = provider || 'gemini';
-        
+
         let apiCall;
         switch (selectedProvider) {
             case 'openai':
@@ -176,12 +433,15 @@ browser.runtime.onMessage.addListener(function(request, sender, sendResponse) {
             case 'grok':
                 apiCall = callGrok(apiKey, requestBody);
                 break;
+            case 'opencode':
+                apiCall = callOpenCode(opencodeConfig, requestBody, pageKey);
+                break;
             case 'gemini':
             default:
                 apiCall = callGemini(apiKey, requestBody);
                 break;
         }
-        
+
         apiCall
             .then(text => {
                 sendResponse({ success: true, text: text });
@@ -189,7 +449,7 @@ browser.runtime.onMessage.addListener(function(request, sender, sendResponse) {
             .catch(error => {
                 sendResponse({ success: false, error: error.message });
             });
-        
+
         return true; // Keep the message channel open for async response
     }
 });

--- a/content.js
+++ b/content.js
@@ -37,12 +37,22 @@
                 <option value="anthropic">Anthropic (Claude)</option>
                 <option value="openrouter">OpenRouter</option>
                 <option value="grok">Grok (xAI)</option>
+                <option value="opencode">OpenCode (local)</option>
             </select>
             <label for="ai-model-select" style="margin-top:8px">Model</label>
             <select id="ai-model-select" class="ai-settings-select"></select>
-            <label for="ai-sync-key" style="margin-top:8px">API Key</label>
-            <input type="password" id="ai-sync-key" placeholder="Enter API key...">
-            <div class="settings-hint">Key for the selected AI provider</div>
+            <div id="ai-api-key-group">
+                <label for="ai-sync-key" style="margin-top:8px">API Key</label>
+                <input type="password" id="ai-sync-key" placeholder="Enter API key...">
+                <div class="settings-hint">Key for the selected AI provider</div>
+            </div>
+            <div id="ai-opencode-group" style="display:none; margin-top:8px;">
+                <label for="ai-opencode-url">OpenCode Server URL</label>
+                <input type="text" id="ai-opencode-url" placeholder="http://127.0.0.1:4096">
+                <label for="ai-opencode-password" style="margin-top:8px">Server Password (optional)</label>
+                <input type="password" id="ai-opencode-password" placeholder="OPENCODE_SERVER_PASSWORD">
+                <div class="settings-hint" id="ai-opencode-status">Models load from your OpenCode server.</div>
+            </div>
             <label for="ai-opacity-slider" style="margin-top:8px">Chat Opacity</label>
             <div style="display:flex;align-items:center;gap:8px">
                 <input type="range" id="ai-opacity-slider" min="10" max="100" step="5" value="95" style="flex:1">
@@ -227,6 +237,8 @@
     let currentImageMimeType = null;
     let currentProvider = 'gemini';
     let _settingsMinH = 354; // measured once at init
+    const OPENCODE_DEFAULT_URL = 'http://127.0.0.1:4096';
+    let opencodeModelCache = { key: '', models: [] };
 
     // Available models per provider
     const PROVIDER_MODELS = {
@@ -267,11 +279,9 @@
         ],
     };
 
-    // Populate model dropdown for given provider, optionally pre-selecting savedModel
-    function populateModels(provider, savedModel) {
+    function setModelOptions(models, savedModel) {
         const modelSelect = document.getElementById('ai-model-select');
         modelSelect.innerHTML = '';
-        const models = PROVIDER_MODELS[provider] || [];
         models.forEach(m => {
             const opt = document.createElement('option');
             opt.value = m.value;
@@ -280,6 +290,87 @@
         });
         if (savedModel && models.some(m => m.value === savedModel)) {
             modelSelect.value = savedModel;
+        } else if (models.length > 0) {
+            modelSelect.value = models[0].value;
+        }
+    }
+
+    function normalizeOpenCodeUrl(url) {
+        const raw = (url || '').trim();
+        if (!raw) return OPENCODE_DEFAULT_URL;
+        return raw.replace(/\/$/, '');
+    }
+
+    function getPageSessionKey() {
+        return `${window.location.origin}${window.location.pathname}${window.location.search}`;
+    }
+
+    function updateProviderSettingsUI(provider) {
+        const isOpenCode = provider === 'opencode';
+        document.getElementById('ai-api-key-group').style.display = isOpenCode ? 'none' : 'block';
+        document.getElementById('ai-opencode-group').style.display = isOpenCode ? 'block' : 'none';
+    }
+
+    function fetchOpenCodeModels(opencodeConfig) {
+        return new Promise((resolve, reject) => {
+            browser.runtime.sendMessage({
+                type: 'getOpenCodeModels',
+                opencodeConfig
+            }, (response) => {
+                if (browser.runtime.lastError) {
+                    reject(new Error(browser.runtime.lastError.message));
+                    return;
+                }
+                if (!response || !response.success) {
+                    reject(new Error(response && response.error ? response.error : 'Failed to load models'));
+                    return;
+                }
+                resolve(response);
+            });
+        });
+    }
+
+    // Populate model dropdown for given provider, optionally pre-selecting savedModel
+    async function populateModels(provider, savedModel, settings) {
+        if (provider !== 'opencode') {
+            setModelOptions(PROVIDER_MODELS[provider] || [], savedModel);
+            return;
+        }
+
+        const modelSelect = document.getElementById('ai-model-select');
+        const status = document.getElementById('ai-opencode-status');
+        modelSelect.innerHTML = '';
+        const loading = document.createElement('option');
+        loading.value = '';
+        loading.textContent = 'Loading models...';
+        modelSelect.appendChild(loading);
+
+        const conf = settings || await getApiKey();
+        const opencodeConfig = {
+            baseUrl: normalizeOpenCodeUrl(conf.opencodeUrl),
+            password: conf.opencodePassword || ''
+        };
+        const cacheKey = `${opencodeConfig.baseUrl}::${opencodeConfig.password}`;
+
+        try {
+            let serverModels = [];
+            let defaultModel = '';
+
+            if (opencodeModelCache.key === cacheKey && opencodeModelCache.models.length > 0) {
+                serverModels = opencodeModelCache.models;
+            } else {
+                const data = await fetchOpenCodeModels(opencodeConfig);
+                serverModels = Array.isArray(data.models) ? data.models : [];
+                defaultModel = data.defaultModel || '';
+                opencodeModelCache = { key: cacheKey, models: serverModels };
+            }
+
+            const merged = [{ value: '', label: 'Server default model' }].concat(serverModels);
+            setModelOptions(merged, savedModel || defaultModel || '');
+            status.textContent = `Connected to ${opencodeConfig.baseUrl}`;
+        } catch (error) {
+            setModelOptions([{ value: '', label: 'Server default model' }], '');
+            status.textContent = `Model fetch failed: ${error.message}`;
         }
     }
 
@@ -492,11 +583,23 @@
     // Get API key, provider and model from storage
     async function getApiKey() {
         return new Promise((resolve) => {
-            browser.storage.local.get(['geminiApiKey', 'apiProvider', 'apiModel', 'chatOpacity', 'btnOpacity', 'chatWidth', 'chatHeight'], (result) => {
+            browser.storage.local.get([
+                'geminiApiKey',
+                'apiProvider',
+                'apiModel',
+                'opencodeServerUrl',
+                'opencodePassword',
+                'chatOpacity',
+                'btnOpacity',
+                'chatWidth',
+                'chatHeight'
+            ], (result) => {
                 resolve({
                     key: result.geminiApiKey || null,
                     provider: result.apiProvider || 'gemini',
                     model: result.apiModel || null,
+                    opencodeUrl: result.opencodeServerUrl || OPENCODE_DEFAULT_URL,
+                    opencodePassword: result.opencodePassword || '',
                     opacity: result.chatOpacity != null ? result.chatOpacity : 0.95,
                     btnOpacity: result.btnOpacity != null ? result.btnOpacity : 0.25,
                     chatWidth: result.chatWidth != null ? result.chatWidth : 320,
@@ -507,9 +610,19 @@
     }
 
     // Save API key, provider and model
-    async function saveApiKey(key, provider, model, opacity, btnOp, chatWidth, chatHeight) {
+    async function saveApiKey(key, provider, model, opencodeUrl, opencodePassword, opacity, btnOp, chatWidth, chatHeight) {
         return new Promise((resolve) => {
-            browser.storage.local.set({ geminiApiKey: key, apiProvider: provider, apiModel: model, chatOpacity: opacity, btnOpacity: btnOp, chatWidth, chatHeight }, () => {
+            browser.storage.local.set({
+                geminiApiKey: key,
+                apiProvider: provider,
+                apiModel: model,
+                opencodeServerUrl: normalizeOpenCodeUrl(opencodeUrl),
+                opencodePassword: opencodePassword || '',
+                chatOpacity: opacity,
+                btnOpacity: btnOp,
+                chatWidth,
+                chatHeight
+            }, () => {
                 currentProvider = provider;
                 resolve();
             });
@@ -575,6 +688,19 @@
         autoSave();
     });
     // ─────────────────────────────────────────────────────────────────────────
+
+    function imageFilenameForMime(mimeType) {
+        const map = {
+            'image/jpeg': 'image.jpg',
+            'image/png': 'image.png',
+            'image/webp': 'image.webp',
+            'image/gif': 'image.gif',
+            'image/bmp': 'image.bmp',
+            'image/heic': 'image.heic',
+            'image/heif': 'image.heif'
+        };
+        return map[mimeType] || 'image.bin';
+    }
 
     // Build request body based on provider
     function buildRequestBody(provider, model, text, imageBase64, imageMimeType) {
@@ -652,17 +778,50 @@
             };
         }
 
+        if (provider === 'opencode') {
+            const parts = [];
+            if (imageBase64 && imageMimeType) {
+                parts.push({
+                    type: 'file',
+                    mime: imageMimeType,
+                    filename: imageFilenameForMime(imageMimeType),
+                    url: `data:${imageMimeType};base64,${imageBase64}`
+                });
+            }
+            parts.push({ type: 'text', text: userText });
+
+            const body = {
+                system: instruction,
+                parts
+            };
+
+            if (model && model.includes('/')) {
+                const splitIndex = model.indexOf('/');
+                body.model = {
+                    providerID: model.slice(0, splitIndex),
+                    modelID: model.slice(splitIndex + 1)
+                };
+            }
+
+            return body;
+        }
+
         return {};
     }
 
     // Send request to selected AI provider
     async function sendToAI(text, imageBase64 = null, imageMimeType = null) {
-        const { key: apiKey, provider, model } = await getApiKey();
-        if (!apiKey) {
+        const settings = await getApiKey();
+        const { key: apiKey, provider, model } = settings;
+        if (provider !== 'opencode' && !apiKey) {
             throw new Error('API key not configured. Click ⚙️ to set up.');
         }
 
         const requestBody = buildRequestBody(provider, model, text, imageBase64, imageMimeType);
+        const opencodeConfig = {
+            baseUrl: normalizeOpenCodeUrl(settings.opencodeUrl),
+            password: settings.opencodePassword || ''
+        };
 
         // Send request through background script to avoid CORS
         return new Promise((resolve, reject) => {
@@ -670,7 +829,9 @@
                 type: 'sendToAPI',
                 apiKey: apiKey,
                 requestBody: requestBody,
-                provider: provider
+                provider: provider,
+                opencodeConfig,
+                pageKey: getPageSessionKey()
             }, (response) => {
                 if (browser.runtime.lastError) {
                     reject(new Error(browser.runtime.lastError.message));
@@ -716,12 +877,18 @@
 
     // Load saved settings
     async function loadSettings() {
-        const { key, provider, model, opacity, btnOpacity, chatWidth, chatHeight } = await getApiKey();
+        const { key, provider, model, opencodeUrl, opencodePassword, opacity, btnOpacity, chatWidth, chatHeight } = await getApiKey();
         if (key) document.getElementById('ai-sync-key').value = key;
+        document.getElementById('ai-opencode-url').value = normalizeOpenCodeUrl(opencodeUrl);
+        document.getElementById('ai-opencode-password').value = opencodePassword || '';
         const resolvedProvider = provider || 'gemini';
         currentProvider = resolvedProvider;
         document.getElementById('ai-provider-select').value = resolvedProvider;
-        populateModels(resolvedProvider, model);
+        updateProviderSettingsUI(resolvedProvider);
+        await populateModels(resolvedProvider, model, {
+            opencodeUrl: normalizeOpenCodeUrl(opencodeUrl),
+            opencodePassword: opencodePassword || ''
+        });
 
         const pct = Math.round(opacity * 100);
         document.getElementById('ai-opacity-slider').value = pct;
@@ -740,11 +907,13 @@
         const key      = document.getElementById('ai-sync-key').value.trim();
         const provider = document.getElementById('ai-provider-select').value;
         const model    = document.getElementById('ai-model-select').value;
+        const opencodeUrl = normalizeOpenCodeUrl(document.getElementById('ai-opencode-url').value);
+        const opencodePassword = document.getElementById('ai-opencode-password').value;
         const opacity  = parseInt(document.getElementById('ai-opacity-slider').value) / 100;
         const btnOp    = parseInt(document.getElementById('ai-btn-opacity-slider').value) / 100;
         const chatWidth  = chatbox.offsetWidth  || 320;
         const chatHeight = chatbox.offsetHeight || 480;
-        await saveApiKey(key, provider, model, opacity, btnOp, chatWidth, chatHeight);
+        await saveApiKey(key, provider, model, opencodeUrl, opencodePassword, opacity, btnOp, chatWidth, chatHeight);
     }
 
     // Event listeners  (click handled by mouseup drag logic above)
@@ -769,15 +938,38 @@
     document.getElementById('ai-settings-toggle').addEventListener('click', toggleSettings);
 
     // Provider change: repopulate models then auto-save
-    document.getElementById('ai-provider-select').addEventListener('change', () => {
+    document.getElementById('ai-provider-select').addEventListener('change', async () => {
         const provider = document.getElementById('ai-provider-select').value;
-        populateModels(provider, null);
-        autoSave();
+        updateProviderSettingsUI(provider);
+        await populateModels(provider, null);
+        await autoSave();
     });
 
     document.getElementById('ai-model-select').addEventListener('change', () => autoSave());
 
     document.getElementById('ai-sync-key').addEventListener('blur', () => autoSave());
+    document.getElementById('ai-opencode-password').addEventListener('blur', async () => {
+        const settings = {
+            opencodeUrl: normalizeOpenCodeUrl(document.getElementById('ai-opencode-url').value),
+            opencodePassword: document.getElementById('ai-opencode-password').value
+        };
+        await autoSave();
+        opencodeModelCache = { key: '', models: [] };
+        if (document.getElementById('ai-provider-select').value === 'opencode') {
+            await populateModels('opencode', document.getElementById('ai-model-select').value, settings);
+        }
+    });
+    document.getElementById('ai-opencode-url').addEventListener('blur', async () => {
+        const settings = {
+            opencodeUrl: normalizeOpenCodeUrl(document.getElementById('ai-opencode-url').value),
+            opencodePassword: document.getElementById('ai-opencode-password').value
+        };
+        await autoSave();
+        opencodeModelCache = { key: '', models: [] };
+        if (document.getElementById('ai-provider-select').value === 'opencode') {
+            await populateModels('opencode', document.getElementById('ai-model-select').value, settings);
+        }
+    });
 
     document.getElementById('ai-opacity-slider').addEventListener('input', (e) => {
         const pct = parseInt(e.target.value);

--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,9 @@
     "*://api.openai.com/*",
     "*://api.anthropic.com/*",
     "*://openrouter.ai/*",
-    "*://api.x.ai/*"
+    "*://api.x.ai/*",
+    "http://127.0.0.1/*",
+    "http://localhost/*"
   ],
   "web_accessible_resources": [
     "katex/katex.min.js",


### PR DESCRIPTION
## Summary
- add `OpenCode (local)` as a first-class provider in the floating assistant, including provider-specific settings for local server URL and optional password
- implement OpenCode API integration in the background script using `/global/health`, `/config/providers`, `/session`, and `/session/{id}/message`, with per-page session reuse and automatic session recreation on 404

## Verification
- built the extension package with `bash package.sh`
- validated syntax with `node --check background.js` and `node --check content.js`
- validated manifest JSON with `python -m json.tool manifest.json`