### PR TITLE
fix: mobile support — drag, resize, screenshot, tap-to-close

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "clipboard-manager-extension",
+      "dependencies": {
+        "html2canvas": "^1.4.1",
+      },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
         "@types/firefox-webext-browser": "^120.0.4",
@@ -189,6 +192,8 @@
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
+    "base64-arraybuffer": ["base64-arraybuffer@1.0.2", "", {}, "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ=="],
+
     "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
@@ -204,6 +209,8 @@
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "css-line-break": ["css-line-break@2.1.0", "", { "dependencies": { "utrie": "^1.0.2" } }, "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -254,6 +261,8 @@
     "globals": ["globals@16.5.0", "", {}, "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "html2canvas": ["html2canvas@1.4.1", "", { "dependencies": { "css-line-break": "^2.1.0", "text-segmentation": "^1.0.3" } }, "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -335,6 +344,8 @@
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "text-segmentation": ["text-segmentation@1.0.3", "", { "dependencies": { "utrie": "^1.0.2" } }, "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw=="],
+
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
@@ -348,6 +359,8 @@
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "utrie": ["utrie@1.0.2", "", { "dependencies": { "base64-arraybuffer": "^1.0.2" } }, "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw=="],
 
     "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
 

--- a/docs/superpowers/specs/2026-03-30-mobile-support-design.md
+++ b/docs/superpowers/specs/2026-03-30-mobile-support-design.md
@@ -1,0 +1,96 @@
+# Mobile Support Design
+
+**Date:** 2026-03-30
+**Branch:** `fix/mobile-v2` (new branch off `main`)
+**Source context:** Integrates and improves on PR #20 (`fix/mobile`), which was branched off an older version and is not being merged directly.
+
+---
+
+## Goal
+
+Make the extension fully functional on mobile browsers by fixing:
+1. Screenshot capture (native API unavailable on mobile)
+2. Button drag (mouse events don't fire on touch screens)
+3. Chat panel resize (same root cause as drag)
+4. Button tap-to-close (chat wouldn't close when tapping the button again)
+5. Crash on load due to `browser.menus` being undefined on mobile Firefox
+
+All existing desktop behavior must remain unchanged.
+
+---
+
+## Architecture
+
+No new files. All changes are targeted edits to existing files. `isMobile` is a single boolean on `OverlayState` that gates mobile-specific code paths.
+
+---
+
+## Changes by File
+
+### `src/content/types.ts`
+Add `isMobile: boolean` to `OverlayState` interface.
+
+### `src/content/state.ts`
+Initialize `isMobile: false` in `createOverlayState()`.
+
+### `src/content/app.ts`
+- Import `html2canvas` at the top.
+- After `createOverlayState()`, set `state.isMobile` via user-agent regex (same pattern as PR #20).
+- Replace both inline `captureTab` arrow functions with a single shared `captureTab` function:
+  - If `state.isMobile`: call `html2canvas(document.body)` directly, return `{ success, base64, mimeType: "image/png" }`.
+  - Otherwise: call `browser.runtime.sendMessage({ type: "captureTab" })` as before (no fallback — desktop native capture works reliably).
+
+### `src/background/lifecycle.ts`
+Wrap `browser.menus.removeAll()` and `browser.menus.onClicked.addListener()` in `if (browser.menus)` guard. Mobile Firefox does not expose this API and crashes without the guard.
+
+### `src/content/events/drag.ts`
+Replace all `mousedown`/`mousemove`/`mouseup` listeners with `pointerdown`/`pointermove`/`pointerup`:
+- On `pointerdown` on `aiButton`: call `event.currentTarget.setPointerCapture(event.pointerId)` so subsequent pointer events are received even if the finger slides off the element.
+- Drag threshold: `4` px when `event.pointerType === "mouse"`, `8` px for `"touch"` or `"pen"`.
+- On `pointerup` with no drag (`!state.dragMoved`): call `chat.toggle()`. This fixes tap-to-close on mobile (same code path as desktop click).
+- Resize corner gets the same pointer event treatment. `setPointerCapture` called on `pointerdown` there too.
+- Desktop behavior is identical — pointer events fire for mouse input with `pointerType === "mouse"`, so no behavioral change for existing desktop users.
+
+### `src/content/events/runtime.ts`
+Add a `pointerdown` listener on `document`:
+```ts
+document.addEventListener("pointerdown", (event) => {
+  if (state.isMobile && state.isOpen && !chatbox.contains(event.target as Node)) {
+    chat.close();
+  }
+});
+```
+This closes the chat when tapping outside it on mobile.
+
+### `src/content/messages.ts`
+Port `imageBase64` support from PR #20:
+- Add `imageBase64?: string | null` to `StoredChatMessage` interface.
+- Include `imageBase64` in the equality check to prevent duplicate suppression.
+- Pass `imageBase64` through `appendMessage` and `addUserMessage`.
+- When rendering a user message that has `imageBase64`, prepend a clickable `<img>` element above the text.
+- Persist and restore `imageBase64` in `loadHistory`.
+
+### `package.json` + `bun.lock`
+Add `html2canvas@^1.4.1` as a runtime dependency.
+
+---
+
+## Data Flow (screenshot path)
+
+```
+quiz trigger
+  → runQuizRequest (quiz-shared.ts)
+    → captureTab() [app.ts]
+        mobile: html2canvas(document.body) → base64 PNG
+        desktop: browser.runtime.sendMessage("captureTab") → base64 PNG
+    → sendToAI(prompt, base64, "image/png", contextMessages)
+    → AI response displayed
+```
+
+---
+
+## Out of Scope
+
+- `quiz-shared.ts` ordering change from PR #20 (show user message after screenshot) — not porting; current behavior on main is acceptable and the change introduces edge-case complexity.
+- Any UI layout changes for mobile (font size, panel sizing, etc.).
+- Detection of mobile via feature detection instead of user-agent — user-agent is sufficient here and consistent with the existing approach.

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.26.1",
     "vite": "^6.2.2"
+  },
+  "dependencies": {
+    "html2canvas": "^1.4.1"
   }
 }

--- a/src/background/lifecycle.ts
+++ b/src/background/lifecycle.ts
@@ -7,17 +7,19 @@ export function setupLifecycle() {
     }
   });
 
-  browser.menus.removeAll().then(function () {
-    browser.menus.create({
-      id: "quiz-screenshot",
-      title: "Add to clipboard",
-      contexts: ["all"]
+  if (browser.menus) {
+    browser.menus.removeAll().then(function () {
+      browser.menus.create({
+        id: "quiz-screenshot",
+        title: "Add to clipboard",
+        contexts: ["all"]
+      });
     });
-  });
 
-  browser.menus.onClicked.addListener(function (info, tab) {
-    if (info.menuItemId === "quiz-screenshot" && tab && tab.id) {
-      browser.tabs.sendMessage(tab.id, { type: "quizScreenshot" });
-    }
-  });
+    browser.menus.onClicked.addListener(function (info, tab) {
+      if (info.menuItemId === "quiz-screenshot" && tab && tab.id) {
+        browser.tabs.sendMessage(tab.id, { type: "quizScreenshot" });
+      }
+    });
+  }
 }

--- a/src/content/app.ts
+++ b/src/content/app.ts
@@ -1,3 +1,4 @@
+import html2canvas from "html2canvas";
 import { createChatController } from "./chat";
 import { createOverlay } from "./dom";
 import { bindOverlayEvents } from "./events";
@@ -37,6 +38,11 @@ export async function startContentApp(): Promise<void> {
   const theme = createThemeController(chatbox);
   const pendingRequests = new Map<string, PendingRequest>();
   const state = createOverlayState();
+
+  state.isMobile =
+    /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+      navigator.userAgent
+    );
 
   const image = createImageController(state);
 
@@ -115,19 +121,42 @@ export async function startContentApp(): Promise<void> {
     resetConversation
   });
 
+  const captureTab = async () => {
+    if (state.isMobile) {
+      try {
+        const canvas = await html2canvas(document.body, {
+          useCORS: true,
+          logging: false
+        });
+        const dataUrl = canvas.toDataURL("image/png");
+        return {
+          success: true,
+          base64: dataUrl.replace(/^data:image\/png;base64,/, ""),
+          mimeType: "image/png"
+        };
+      } catch {
+        return {
+          success: false,
+          error: "html2canvas capture failed."
+        };
+      }
+    }
+    return browser.runtime.sendMessage({ type: "captureTab" });
+  };
+
   const quiz = createQuizController({
     elements,
     messages,
     beforeSend,
     sendToAI,
-    captureTab: () => browser.runtime.sendMessage({ type: "captureTab" })
+    captureTab
   });
   const quizAutofill = createQuizAutofillController({
     elements,
     messages,
     beforeSend,
     sendToAI,
-    captureTab: () => browser.runtime.sendMessage({ type: "captureTab" })
+    captureTab
   });
 
   layout.loadBtnPos((initialPosition) => {

--- a/src/content/events/drag.ts
+++ b/src/content/events/drag.ts
@@ -28,8 +28,8 @@ export function bindDragEvents({
     }
   });
 
-  aiButton.addEventListener("mousedown", (event) => {
-    if (event.button !== 0) {
+  aiButton.addEventListener("pointerdown", (event) => {
+    if (event.button !== 0 && event.pointerType === "mouse") {
       return;
     }
 
@@ -39,28 +39,31 @@ export function bindDragEvents({
     state.dragStartY = event.clientY;
     state.btnStartLeft = aiButton.offsetLeft;
     state.btnStartTop = aiButton.offsetTop;
+    aiButton.setPointerCapture(event.pointerId);
     event.preventDefault();
   });
 
-  resizeCorner.addEventListener("mousedown", (event) => {
+  resizeCorner.addEventListener("pointerdown", (event) => {
     state.isResizing = true;
     const rect = chatbox.getBoundingClientRect();
     state.resizeAnchorX =
       state.resizeCornerHorizontal === "left" ? rect.right : rect.left;
     state.resizeAnchorY =
       state.resizeCornerVertical === "top" ? rect.bottom : rect.top;
+    resizeCorner.setPointerCapture(event.pointerId);
     event.preventDefault();
     event.stopPropagation();
   });
 
-  document.addEventListener("mousemove", (event) => {
+  document.addEventListener("pointermove", (event) => {
     if (!state.isDragging) {
       return;
     }
 
     const dx = event.clientX - state.dragStartX;
     const dy = event.clientY - state.dragStartY;
-    if (Math.abs(dx) > 4 || Math.abs(dy) > 4) {
+    const threshold = event.pointerType === "mouse" ? 4 : 8;
+    if (Math.abs(dx) > threshold || Math.abs(dy) > threshold) {
       state.dragMoved = true;
     }
     if (state.dragMoved) {
@@ -73,7 +76,7 @@ export function bindDragEvents({
     }
   });
 
-  document.addEventListener("mousemove", (event) => {
+  document.addEventListener("pointermove", (event) => {
     if (!state.isResizing) {
       return;
     }
@@ -134,7 +137,7 @@ export function bindDragEvents({
     chatbox.style.top = `${newTop}px`;
   });
 
-  document.addEventListener("mouseup", () => {
+  document.addEventListener("pointerup", () => {
     if (!state.isDragging) {
       return;
     }
@@ -153,7 +156,7 @@ export function bindDragEvents({
     chat.toggle();
   });
 
-  document.addEventListener("mouseup", () => {
+  document.addEventListener("pointerup", () => {
     if (!state.isResizing) {
       return;
     }

--- a/src/content/events/runtime.ts
+++ b/src/content/events/runtime.ts
@@ -74,6 +74,16 @@ export function bindRuntimeEvents({
     void chat.runQuizAutofill();
   });
 
+  document.addEventListener("pointerdown", (event) => {
+    if (
+      state.isMobile &&
+      state.isOpen &&
+      !chatbox.contains(event.target as Node)
+    ) {
+      chat.close();
+    }
+  });
+
   const darkObserver = new MutationObserver(theme.updateDarkMode);
   darkObserver.observe(document.documentElement, {
     attributes: true,

--- a/src/content/messages.ts
+++ b/src/content/messages.ts
@@ -7,6 +7,7 @@ interface StoredChatMessage {
   text: string;
   providerLabel?: string;
   modelLabel?: string;
+  imageBase64?: string | null;
 }
 
 interface StoredChatDivider {
@@ -71,7 +72,8 @@ export function createMessageController(
       messageA.role === messageB.role &&
       messageA.text === messageB.text &&
       messageA.providerLabel === messageB.providerLabel &&
-      messageA.modelLabel === messageB.modelLabel
+      messageA.modelLabel === messageB.modelLabel &&
+      messageA.imageBase64 === messageB.imageBase64
     );
   }
 
@@ -89,10 +91,16 @@ export function createMessageController(
       return;
     }
 
-    appendMessage(entry.text, entry.role === "user", false, {
-      providerLabel: entry.providerLabel || "",
-      modelLabel: entry.modelLabel || ""
-    });
+    appendMessage(
+      entry.text,
+      entry.role === "user",
+      false,
+      {
+        providerLabel: entry.providerLabel || "",
+        modelLabel: entry.modelLabel || ""
+      },
+      (entry as StoredChatMessage).imageBase64
+    );
   }
 
   function renderHistory(): void {
@@ -158,12 +166,30 @@ export function createMessageController(
     text: string,
     isUser: boolean,
     persist = true,
-    meta?: BotMessageMeta
+    meta?: BotMessageMeta,
+    imageBase64?: string | null
   ): void {
     const messageDiv = document.createElement("div");
     messageDiv.className = isUser ? "ai-msg ai-msg-user" : "ai-msg ai-msg-bot";
     if (isUser) {
-      messageDiv.textContent = text;
+      if (imageBase64) {
+        const img = document.createElement("img");
+        img.src = `data:image/png;base64,${imageBase64}`;
+        img.style.maxWidth = "100%";
+        img.style.borderRadius = "4px";
+        img.style.marginBottom = "8px";
+        img.style.cursor = "pointer";
+        img.onclick = () => {
+          const w = window.open("");
+          w?.document.write(
+            `<img src="data:image/png;base64,${imageBase64}" style="max-width:100%;" />`
+          );
+        };
+        messageDiv.appendChild(img);
+      }
+      const textDiv = document.createElement("div");
+      textDiv.textContent = text;
+      messageDiv.appendChild(textDiv);
     } else {
       if (meta?.providerLabel) {
         const badge = document.createElement("div");
@@ -186,7 +212,8 @@ export function createMessageController(
         role: isUser ? "user" : "bot",
         text,
         providerLabel: meta?.providerLabel,
-        modelLabel: meta?.modelLabel
+        modelLabel: meta?.modelLabel,
+        imageBase64
       });
       persistHistory();
     }
@@ -256,13 +283,16 @@ export function createMessageController(
           : undefined;
       const modelLabel =
         typeof entry.modelLabel === "string" ? entry.modelLabel : undefined;
+      const imageBase64 =
+        typeof entry.imageBase64 === "string" ? entry.imageBase64 : undefined;
 
       entries.push({
         type: "message",
         role,
         text,
         providerLabel,
-        modelLabel
+        modelLabel,
+        imageBase64
       });
       return entries;
     }, []);

--- a/src/content/state.ts
+++ b/src/content/state.ts
@@ -20,6 +20,7 @@ export function createOverlayState(): OverlayState {
     btnStartLeft: 0,
     btnStartTop: 0,
     isResizing: false,
-    viewportNormalizeTimer: null
+    viewportNormalizeTimer: null,
+    isMobile: false
   };
 }

--- a/src/content/types.ts
+++ b/src/content/types.ts
@@ -98,4 +98,5 @@ export interface OverlayState {
   btnStartTop: number;
   isResizing: boolean;
   viewportNormalizeTimer: number | null;
+  isMobile: boolean;
 }


### PR DESCRIPTION
## Summary

- Replace mouse events with Pointer Events API in `drag.ts` so the AI button and chat resize corner can be dragged on touch screens (4px threshold for mouse, 8px for touch)
- Fix button tap-to-close on mobile — `pointerup` with no drag calls `chat.toggle()` same as desktop click
- Use `html2canvas` directly on mobile for screenshot capture (native tab capture API unavailable on mobile Firefox)
- Add tap-outside-to-close: tapping outside the chat panel closes it on mobile
- Guard `browser.menus` with `if (browser.menus)` to prevent crash on mobile Firefox where the API is undefined
- Add `isMobile` boolean to `OverlayState`, detected from user-agent at startup
- Persist and render screenshot images in chat history (`imageBase64` field on stored messages)

## Test Plan

- [ ] On mobile Firefox: load a page, verify the floating button appears and can be dragged to a new position
- [ ] On mobile Firefox: tap the button to open chat, tap it again to close
- [ ] On mobile Firefox: open chat, tap outside it to close
- [ ] On mobile Firefox: open chat, drag the resize corner to resize the panel
- [ ] On mobile Firefox: trigger quiz screenshot — verify html2canvas capture works and image appears in chat
- [ ] On desktop: verify drag, resize, click-to-toggle, and screenshot all still work as before
- [ ] On desktop: verify context menu ("Add to clipboard") still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)